### PR TITLE
Marketplace: Modernize to Go 1.26 and add lint/Docker/Make tooling

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,6 +51,9 @@ jobs:
         cache: true
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      # v7+ installs golangci-lint v2 (matching the v2 .golangci.yml).
+      # Pin to a v2 release built with Go >= the go.mod version, otherwise
+      # golangci-lint refuses to lint a newer-Go module.
+      uses: golangci/golangci-lint-action@v7
       with:
-        version: latest
+        version: v2.12.2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-# This workflow will build a golang project
+# This workflow builds, lints and tests the Go project.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
@@ -9,20 +9,48 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
-  build:
+  build-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'
+        go-version: '1.26.x'
+        cache: true
+
+    - name: Verify dependencies
+      run: |
+        go mod verify
+        go mod tidy
+        git diff --exit-code go.mod go.sum
 
     - name: Build
       run: go build -v ./...
 
+    # The repository tests use testcontainers, which need Docker.
+    # The ubuntu-latest runner ships with Docker pre-installed.
     - name: Test
-      run: go test -v ./...
+      run: go test -race -v ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26.x'
+        cache: true
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # Go workspace file
 go.work
+
+# Build output
+/bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  # The default set already includes errcheck, govet, ineffassign,
+  # staticcheck and unused. We add a few high-signal extras.
+  # (revive is intentionally omitted: its var-naming rule wants `ID`,
+  # while this codebase uses the `Id` convention by design.)
+  enable:
+    - misspell
+    - bodyclose
+    - unconvert
+  settings:
+    staticcheck:
+      checks:
+        - all
+        # QF* are stylistic "quickfix" suggestions (e.g. tagged switches);
+        # they add noise without improving correctness.
+        - -QF1003
+        # ST1003 enforces the `ID` initialism. This codebase uses the
+        # `Id` convention consistently and by design.
+        - -ST1003
+        # ST1000 requires a doc comment on every package; not a convention
+        # this template enforces.
+        - -ST1000
+  exclusions:
+    rules:
+      # Test files frequently ignore errors on cleanup/teardown.
+      - path: _test\.go
+        linters:
+          - errcheck
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build stage ----
+FROM golang:1.26 AS build
+WORKDIR /src
+
+# Cache dependencies first.
+COPY go.mod go.sum ./
+COPY vendor ./vendor
+COPY . .
+
+# Build statically-linked binaries (server + migration tool).
+ENV CGO_ENABLED=0 GOFLAGS=-mod=vendor
+RUN go build -o /out/marketplace ./cmd/marketplace
+RUN go build -o /out/migrate ./migrate.go
+
+# ---- Runtime stage ----
+FROM gcr.io/distroless/static-debian12:nonroot
+WORKDIR /app
+
+COPY --from=build /out/marketplace /app/marketplace
+COPY --from=build /out/migrate /app/migrate
+# Migrations are read at runtime by the migrate tool.
+COPY --from=build /src/migrations /app/migrations
+
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/app/marketplace"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+.DEFAULT_GOAL := help
+
+# Local database URL used by migrate-* targets. Override on the CLI:
+#   make migrate-up DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=disable
+DATABASE_URL ?= postgres://marketplace:marketplace@localhost:5432/marketplace?sslmode=disable
+
+# Packages whose tests require Docker (testcontainers).
+DOCKER_TEST_PKGS := github.com/sklinkert/go-ddd/internal/infrastructure/db/postgres \
+                    github.com/sklinkert/go-ddd/internal/testhelpers
+
+.PHONY: help build run test test-unit lint fmt tidy vendor sqlc migrate-up migrate-down docker-up docker-down
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the server binary
+	go build -o bin/marketplace ./cmd/marketplace
+
+run: ## Run the server locally
+	go run ./cmd/marketplace
+
+test: ## Run all tests with the race detector (needs Docker)
+	go test -race ./...
+
+test-unit: ## Run only tests that don't need Docker
+	go test -race $(filter-out $(DOCKER_TEST_PKGS),$(shell go list ./...))
+
+lint: ## Run golangci-lint
+	golangci-lint run ./...
+
+fmt: ## Format code (gofmt + goimports)
+	golangci-lint fmt ./...
+
+tidy: ## Tidy and re-vendor modules
+	go mod tidy
+	go mod vendor
+
+vendor: ## Re-vendor modules
+	go mod vendor
+
+sqlc: ## Regenerate sqlc code from sql/queries
+	sqlc generate
+
+migrate-up: ## Apply all pending migrations
+	go run migrate.go -database-url "$(DATABASE_URL)" -command up
+
+migrate-down: ## Roll back the last migration
+	go run migrate.go -database-url "$(DATABASE_URL)" -command down -steps 1
+
+docker-up: ## Start Postgres + app via docker compose
+	docker compose up --build
+
+docker-down: ## Stop and remove docker compose resources
+	docker compose down -v

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@
 
 ## Tech Stack Essentials
 
-- **Go 1.24** with idiomatic patterns and testify-powered tests.
+- **Go 1.26** with idiomatic patterns and testify-powered tests.
 - **Echo v4** HTTP stack for REST endpoints.
 - **pgx/v5** and `sqlc` for type-safe PostgreSQL access.
 - **golang-migrate** handling SQL schema migrations
 - **Testcontainers** integration to provision disposable Postgres instances during tests.
 - **google/uuid** helpers for deterministic ID generation inside the domain.
+- **golangci-lint** for static analysis, plus a `Makefile`, `Dockerfile`, and `docker-compose.yml` for a one-command local stack.
 
 ## Design Principles in Action
 
@@ -161,6 +162,20 @@ This will create two files:
 
 ## Getting Started
 
+> Requires **Go 1.26+**. Run `make help` to see all available targets.
+
+### Quickstart with Docker Compose
+
+Bring up Postgres, apply migrations, and start the API in one command:
+
+```bash
+make docker-up        # docker compose up --build
+# API is now available on http://localhost:8080
+make docker-down      # tear everything down
+```
+
+### Local development
+
 1. Clone this repository:
 ```bash
 git clone https://github.com/sklinkert/go-ddd.git
@@ -192,7 +207,20 @@ migrate -path migrations -database $DATABASE_URL up
 
 5. Run the application:
 ```bash
-go run ./cmd/marketplace
+make run            # or: go run ./cmd/marketplace
+# Override the database via the DATABASE_URL env var (libpq DSN or postgres:// URL).
+```
+
+### Common Make targets
+
+```bash
+make build        # build the server binary into ./bin
+make test         # run all tests with the race detector (needs Docker)
+make test-unit    # run only tests that don't require Docker
+make lint         # run golangci-lint
+make fmt          # format the code (gofmt + goimports)
+make migrate-up   # apply migrations against $DATABASE_URL
+make sqlc         # regenerate sqlc code
 ```
 
 ### Contributions

--- a/cmd/marketplace/main.go
+++ b/cmd/marketplace/main.go
@@ -2,23 +2,33 @@ package main
 
 import (
 	"context"
+	"log"
+	"os"
+
 	"github.com/labstack/echo/v4"
 	"github.com/sklinkert/go-ddd/internal/application/services"
 	postgres2 "github.com/sklinkert/go-ddd/internal/infrastructure/db/postgres"
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest"
-	"log"
 )
 
 func main() {
-	dsn := "host=localhost user=marketplace password=marketplace dbname=marketplace port=5432 sslmode=disable"
+	// DATABASE_URL may be a libpq keyword DSN or a postgres:// URL; pgx accepts both.
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "host=localhost user=marketplace password=marketplace dbname=marketplace port=5432 sslmode=disable"
+	}
+
 	port := ":8080"
+	if p := os.Getenv("PORT"); p != "" {
+		port = ":" + p
+	}
 
 	ctx := context.Background()
 	conn, err := postgres2.NewConnection(ctx, dsn)
 	if err != nil {
 		log.Fatalf("Failed to connect to database: %v", err)
 	}
-	defer conn.Close(ctx)
+	defer func() { _ = conn.Close(ctx) }()
 
 	queries := postgres2.NewQueries(conn)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: marketplace
+      POSTGRES_PASSWORD: marketplace
+      POSTGRES_DB: marketplace
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U marketplace -d marketplace"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # One-shot job: applies migrations, then exits.
+  migrate:
+    build: .
+    entrypoint: ["/app/migrate", "-command", "up"]
+    environment:
+      DATABASE_URL: postgres://marketplace:marketplace@postgres:5432/marketplace?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  app:
+    build: .
+    environment:
+      DATABASE_URL: postgres://marketplace:marketplace@postgres:5432/marketplace?sslmode=disable
+      PORT: "8080"
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/sklinkert/go-ddd
 
-go 1.25.0
+go 1.26.0
+
+toolchain go1.26.2
 
 require (
 	github.com/golang-migrate/migrate/v4 v4.19.1

--- a/internal/application/common/product_result.go
+++ b/internal/application/common/product_result.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type ProductResult struct {

--- a/internal/application/common/seller_result.go
+++ b/internal/application/common/seller_result.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type SellerResult struct {

--- a/internal/application/services/product_service.go
+++ b/internal/application/services/product_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+
 	"github.com/sklinkert/go-ddd/internal/application/command"
 	"github.com/sklinkert/go-ddd/internal/application/interfaces"
 	"github.com/sklinkert/go-ddd/internal/application/mapper"
@@ -95,11 +96,9 @@ func (s *ProductService) CreateProduct(productCommand *command.CreateProductComm
 	if idempotencyRecord != nil {
 		responseJSON, _ := json.Marshal(result)
 		idempotencyRecord.SetResponse(string(responseJSON), 200)
-		_, err = s.idempotencyRepo.Create(ctx, idempotencyRecord)
-		if err != nil {
-			// Log error but don't fail the operation
-			// In production, you might want to handle this differently
-		}
+		// Best-effort write: a failed idempotency record must not fail the
+		// operation. Proper structured logging is added in the hardening PR.
+		_, _ = s.idempotencyRepo.Create(ctx, idempotencyRecord)
 	}
 
 	return &result, nil
@@ -213,11 +212,9 @@ func (s *ProductService) UpdateProduct(productCommand *command.UpdateProductComm
 	if idempotencyRecord != nil {
 		responseJSON, _ := json.Marshal(result)
 		idempotencyRecord.SetResponse(string(responseJSON), 200)
-		_, err = s.idempotencyRepo.Create(ctx, idempotencyRecord)
-		if err != nil {
-			// Log error but don't fail the operation
-			// In production, you might want to handle this differently
-		}
+		// Best-effort write: a failed idempotency record must not fail the
+		// operation. Proper structured logging is added in the hardening PR.
+		_, _ = s.idempotencyRepo.Create(ctx, idempotencyRecord)
 	}
 
 	return &result, nil
@@ -273,11 +270,9 @@ func (s *ProductService) DeleteProduct(productCommand *command.DeleteProductComm
 	if idempotencyRecord != nil {
 		responseJSON, _ := json.Marshal(result)
 		idempotencyRecord.SetResponse(string(responseJSON), 200)
-		_, err = s.idempotencyRepo.Create(ctx, idempotencyRecord)
-		if err != nil {
-			// Log error but don't fail the operation
-			// In production, you might want to handle this differently
-		}
+		// Best-effort write: a failed idempotency record must not fail the
+		// operation. Proper structured logging is added in the hardening PR.
+		_, _ = s.idempotencyRepo.Create(ctx, idempotencyRecord)
 	}
 
 	return &result, nil

--- a/internal/application/services/product_service_test.go
+++ b/internal/application/services/product_service_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/sklinkert/go-ddd/internal/application/command"
 	"github.com/sklinkert/go-ddd/internal/application/query"
 	"github.com/sklinkert/go-ddd/internal/domain/entities"
-	"testing"
 )
 
 // MockProductRepository is a mock implementation of the ProductRepository interface

--- a/internal/application/services/seller_service.go
+++ b/internal/application/services/seller_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+
 	"github.com/sklinkert/go-ddd/internal/application/command"
 	"github.com/sklinkert/go-ddd/internal/application/interfaces"
 	"github.com/sklinkert/go-ddd/internal/application/mapper"
@@ -73,11 +74,9 @@ func (s *SellerService) CreateSeller(sellerCommand *command.CreateSellerCommand)
 	if idempotencyRecord != nil {
 		responseJSON, _ := json.Marshal(result)
 		idempotencyRecord.SetResponse(string(responseJSON), 200)
-		_, err = s.idempotencyRepo.Create(ctx, idempotencyRecord)
-		if err != nil {
-			// Log error but don't fail the operation
-			// In production, you might want to handle this differently
-		}
+		// Best-effort write: a failed idempotency record must not fail the
+		// operation. Proper structured logging is added in the hardening PR.
+		_, _ = s.idempotencyRepo.Create(ctx, idempotencyRecord)
 	}
 
 	return &result, nil
@@ -170,11 +169,9 @@ func (s *SellerService) UpdateSeller(updateCommand *command.UpdateSellerCommand)
 	if idempotencyRecord != nil {
 		responseJSON, _ := json.Marshal(result)
 		idempotencyRecord.SetResponse(string(responseJSON), 200)
-		_, err = s.idempotencyRepo.Create(ctx, idempotencyRecord)
-		if err != nil {
-			// Log error but don't fail the operation
-			// In production, you might want to handle this differently
-		}
+		// Best-effort write: a failed idempotency record must not fail the
+		// operation. Proper structured logging is added in the hardening PR.
+		_, _ = s.idempotencyRepo.Create(ctx, idempotencyRecord)
 	}
 
 	return &result, nil
@@ -231,11 +228,9 @@ func (s *SellerService) DeleteSeller(sellerCommand *command.DeleteSellerCommand)
 	if idempotencyRecord != nil {
 		responseJSON, _ := json.Marshal(result)
 		idempotencyRecord.SetResponse(string(responseJSON), 200)
-		_, err = s.idempotencyRepo.Create(ctx, idempotencyRecord)
-		if err != nil {
-			// Log error but don't fail the operation
-			// In production, you might want to handle this differently
-		}
+		// Best-effort write: a failed idempotency record must not fail the
+		// operation. Proper structured logging is added in the hardening PR.
+		_, _ = s.idempotencyRepo.Create(ctx, idempotencyRecord)
 	}
 
 	return &result, nil

--- a/internal/application/services/seller_service_test.go
+++ b/internal/application/services/seller_service_test.go
@@ -3,11 +3,12 @@ package services
 import (
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/sklinkert/go-ddd/internal/application/command"
 	"github.com/sklinkert/go-ddd/internal/application/query"
 	"github.com/sklinkert/go-ddd/internal/domain/entities"
-	"testing"
 )
 
 // MockSellerRepository is a mock implementation of the SellerRepository interface

--- a/internal/domain/entities/product.go
+++ b/internal/domain/entities/product.go
@@ -2,8 +2,9 @@ package entities
 
 import (
 	"errors"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Product struct {

--- a/internal/domain/entities/product_test.go
+++ b/internal/domain/entities/product_test.go
@@ -1,8 +1,9 @@
 package entities
 
 import (
-	"github.com/google/uuid"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestNewProduct(t *testing.T) {

--- a/internal/domain/entities/seller.go
+++ b/internal/domain/entities/seller.go
@@ -2,8 +2,9 @@ package entities
 
 import (
 	"errors"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Seller struct {

--- a/internal/domain/entities/seller_test.go
+++ b/internal/domain/entities/seller_test.go
@@ -1,8 +1,9 @@
 package entities
 
 import (
-	"github.com/google/uuid"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestNewSeller(t *testing.T) {

--- a/internal/infrastructure/db/postgres/connection.go
+++ b/internal/infrastructure/db/postgres/connection.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+
 	"github.com/jackc/pgx/v5"
 	db "github.com/sklinkert/go-ddd/internal/infrastructure/db/sqlc"
 )

--- a/internal/infrastructure/db/postgres/helpers.go
+++ b/internal/infrastructure/db/postgres/helpers.go
@@ -2,13 +2,14 @@ package postgres
 
 import (
 	"fmt"
-	"github.com/jackc/pgx/v5/pgtype"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func timestamptzFromTime(t time.Time) pgtype.Timestamptz {
 	var ts pgtype.Timestamptz
-	ts.Scan(t)
+	_ = ts.Scan(t)
 	return ts
 }
 
@@ -22,7 +23,7 @@ func timeFromTimestamptz(ts pgtype.Timestamptz) time.Time {
 func numericFromFloat64(f float64) pgtype.Numeric {
 	var n pgtype.Numeric
 	// Convert float64 to string first, then scan
-	n.Scan(fmt.Sprintf("%.2f", f))
+	_ = n.Scan(fmt.Sprintf("%.2f", f))
 	return n
 }
 

--- a/internal/infrastructure/db/postgres/sqlc_seller_repository.go
+++ b/internal/infrastructure/db/postgres/sqlc_seller_repository.go
@@ -81,16 +81,6 @@ func (repo *SqlcSellerRepository) Delete(id uuid.UUID) error {
 	return repo.queries.DeleteSeller(ctx, id)
 }
 
-func fromSqlcSeller(dbSeller *db.Seller) *entities.Seller {
-	seller := &entities.Seller{
-		Name:      dbSeller.Name,
-		CreatedAt: timeFromTimestamptz(dbSeller.CreatedAt),
-		UpdatedAt: timeFromTimestamptz(dbSeller.UpdatedAt),
-	}
-	seller.Id = dbSeller.ID
-	return seller
-}
-
 func fromSqlcSellerRow(dbSeller *db.GetSellerByIdRow) *entities.Seller {
 	seller := &entities.Seller{
 		Name:      dbSeller.Name,

--- a/internal/interface/api/rest/product_controller.go
+++ b/internal/interface/api/rest/product_controller.go
@@ -1,6 +1,8 @@
 package rest
 
 import (
+	"net/http"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -8,7 +10,6 @@ import (
 	"github.com/sklinkert/go-ddd/internal/application/query"
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest/dto/mapper"
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest/dto/request"
-	"net/http"
 )
 
 type ProductController struct {

--- a/internal/interface/api/rest/seller_controller.go
+++ b/internal/interface/api/rest/seller_controller.go
@@ -1,6 +1,8 @@
 package rest
 
 import (
+	"net/http"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/sklinkert/go-ddd/internal/application/command"
@@ -8,7 +10,6 @@ import (
 	"github.com/sklinkert/go-ddd/internal/application/query"
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest/dto/mapper"
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest/dto/request"
-	"net/http"
 )
 
 type SellerController struct {

--- a/internal/interface/api/rest_test/mock_product_service_test.go
+++ b/internal/interface/api/rest_test/mock_product_service_test.go
@@ -1,12 +1,13 @@
 package rest_test
 
 import (
+	"time"
+
 	"github.com/sklinkert/go-ddd/internal/application/command"
 	"github.com/sklinkert/go-ddd/internal/application/mapper"
 	"github.com/sklinkert/go-ddd/internal/application/query"
 	"github.com/sklinkert/go-ddd/internal/domain/entities"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 type MockProductService struct {

--- a/internal/interface/api/rest_test/mock_seller_service_test.go
+++ b/internal/interface/api/rest_test/mock_seller_service_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"errors"
+
 	"github.com/google/uuid"
 	"github.com/sklinkert/go-ddd/internal/application/command"
 	"github.com/sklinkert/go-ddd/internal/application/interfaces"

--- a/internal/interface/api/rest_test/product_controller_test.go
+++ b/internal/interface/api/rest_test/product_controller_test.go
@@ -3,15 +3,16 @@ package rest_test
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/sklinkert/go-ddd/internal/application/command"
 	"github.com/sklinkert/go-ddd/internal/application/common"
 	"github.com/sklinkert/go-ddd/internal/domain/entities"
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest/dto/response"
 	"github.com/stretchr/testify/mock"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 
 	"github.com/labstack/echo/v4"
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest"

--- a/internal/interface/api/rest_test/seller_controller_test.go
+++ b/internal/interface/api/rest_test/seller_controller_test.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/labstack/echo/v4"
 	"github.com/sklinkert/go-ddd/internal/application/command"
 	"github.com/sklinkert/go-ddd/internal/domain/entities"
@@ -11,9 +15,6 @@ import (
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest/dto/request"
 	"github.com/sklinkert/go-ddd/internal/interface/api/rest/dto/response"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestCreateSeller(t *testing.T) {

--- a/migrate.go
+++ b/migrate.go
@@ -33,7 +33,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to connect to database:", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	driver, err := postgres.WithInstance(db, &postgres.Config{})
 	if err != nil {
@@ -44,7 +44,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to create migrate instance:", err)
 	}
-	defer m.Close()
+	defer func() { _, _ = m.Close() }()
 
 	switch *command {
 	case "up":


### PR DESCRIPTION
## What

Brings the build, CI and local-dev surface of the template up to current standards. This is the first of three focused PRs (this one = tooling; next = correctness/hardening; last = test coverage).

- **Go 1.26**: `go.mod` now targets `go 1.26.0` (+ `toolchain go1.26.2`).
- **Modern CI** (`.github/workflows/go.yml`): `actions/checkout@v4`, `actions/setup-go@v5` on `1.26.x` with module caching, a `go.mod`/`go.sum` drift check, `go test -race`, and a dedicated **golangci-lint** job.
- **Linting** (`.golangci.yml`, golangci-lint v2): `errcheck`, `govet`, `staticcheck`, `ineffassign`, `unused`, `misspell`, `bodyclose`, `unconvert`, plus `gofmt`/`goimports` formatters. `ST1003` (ID initialism) and `ST1000` (package docs) are disabled to respect the existing `Id` house style; `QF1003` disabled as low-signal.
- **Containerization**: multi-stage `Dockerfile` (server + migrate tool on a distroless runtime) and `docker-compose.yml` (postgres:17 + one-shot migrate job + app).
- **Makefile**: `build`, `run`, `test`, `test-unit` (Docker-free packages), `lint`, `fmt`, `tidy`, `sqlc`, `migrate-up/down`, `docker-up/down`.
- **Config from env**: `main.go` now reads `DATABASE_URL` (libpq DSN or `postgres://` URL) and `PORT` so the app runs in containers. (Structured logging + graceful shutdown come in PR #2.)
- **Lint fixups** (no behavior change): explicit error-ignores, removed dead `fromSqlcSeller`, dropped empty best-effort idempotency-write branches, goimports grouping across the tree.
- **README**: Go 1.26, docker-compose quickstart, Make targets.

## Why

Go 1.22 + outdated GitHub Actions and the absence of linting/containerization no longer reflect a "state of the art" reference template. Dependencies were already current (no module updates available), so the gap was tooling and the Go version.

## How to test

```bash
make lint            # golangci-lint: 0 issues
make build           # builds ./bin/marketplace
go test -race ./...  # all green (postgres/testhelpers packages need Docker)
make docker-up       # postgres + migrations + app; API on :8080
```

> Note: `GET /api/v1/products/{unknown-id}` still returns **500** here — that not-found→404 bug is fixed in PR #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)