### PR TITLE
CI: Report test coverage to Codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,12 @@ jobs:
     # The repository tests use testcontainers, which need Docker.
     # The ubuntu-latest runner ships with Docker pre-installed.
     - name: Test
-      run: go test -race -v ./...
+      run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: coverage.out
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Go-DDD: Build Domain-Driven Go Services Fast
 
 [![CI](https://github.com/sklinkert/go-ddd/actions/workflows/go.yml/badge.svg)](https://github.com/sklinkert/go-ddd/actions/workflows/go.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sklinkert/go-ddd)](https://goreportcard.com/report/github.com/sklinkert/go-ddd)
+[![codecov](https://codecov.io/gh/sklinkert/go-ddd/branch/main/graph/badge.svg)](https://codecov.io/gh/sklinkert/go-ddd)
 [![Go Reference](https://pkg.go.dev/badge/github.com/sklinkert/go-ddd.svg)](https://pkg.go.dev/github.com/sklinkert/go-ddd)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/sklinkert/go-ddd)](go.mod)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# Exclude generated code and the entrypoint from coverage metrics.
+ignore:
+  - "internal/infrastructure/db/sqlc"
+  - "cmd"
+  - "migrate.go"
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## What & why

Go Report Card has been sunset, so its README badge now points at a dead service. This replaces it with a Codecov badge and wires coverage upload into the existing CI test job (tokenless upload for public repos). A codecov.yml excludes generated sqlc code and the entrypoint from metrics and keeps status checks informational so coverage never blocks a PR.

## How to test

CI on this PR runs `go test -race -coverprofile=coverage.out ./...` and uploads the report; the Codecov check should appear on the PR after the run.

## Checklist

- [x] `make test` passes (needs Docker)
- [x] `make lint` passes
- [x] Schema changes include up + down migrations and regenerated sqlc code (n/a)
- [x] New behavior is covered by tests (n/a — CI config only)