### PR TITLE
Docs: Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Click **"Use this template"** on GitHub to bootstrap your own service from this 
 
 If this template helps you, **give it a ⭐** — it helps others find it.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sklinkert/go-ddd&type=Date)](https://star-history.com/#sklinkert/go-ddd&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sklinkert/go-ddd&type=Date)](https://star-history.dera.page/#sklinkert/go-ddd&Date)
 
 ### License
 Distributed under the MIT License. See LICENSE for more information.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -335,7 +335,7 @@ make sqlc         # 重新生成 sqlc 代码
 
 如果这个模板对你有帮助，**请点一个 ⭐** —— 这能帮助更多人发现它。
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sklinkert/go-ddd&type=Date)](https://star-history.com/#sklinkert/go-ddd&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sklinkert/go-ddd&type=Date)](https://star-history.dera.page/#sklinkert/go-ddd&Date)
 
 ### 许可证
 


### PR DESCRIPTION
The star history chart is currently broken and renders nothing for visitors. This change points it at a working source so the chart displays correctly again, updating both the English and Chinese READMEs. The chart image keeps using the SVG endpoint and the wrapping link remains hash-based, so only the origin changes.